### PR TITLE
Fix gallery preview image wrapping

### DIFF
--- a/_pages/gallery.html
+++ b/_pages/gallery.html
@@ -89,6 +89,11 @@ img {
   color: white;
 }
 
+.row {
+  display: flex;
+  flex-wrap: wrap;  
+}
+  
 .row:after {
   content: "";
   display: table;


### PR DESCRIPTION
Abandon all hope, ye who render in Block format with widths not in multiples of 10%. Embrace Flexbox, the sensible renderer.